### PR TITLE
reverti os nomes dos ids

### DIFF
--- a/frontend/src/main/resources/templates/signup.html
+++ b/frontend/src/main/resources/templates/signup.html
@@ -45,11 +45,11 @@
                 <div class="input-group1">
 
                     <div class="input-box">
-                        <input id="firstname" type="text" name="firstname" placeholder="Nome" required>
+                        <input id="nome" type="text" name="nome" placeholder="Nome" required>
                     </div>
 
                     <div class="input-box">
-                        <input id="lastname" type="text" name="lastname" placeholder="Sobrenome" required>
+                        <input id="nome" type="text" name="nome" placeholder="Sobrenome" required>
                     </div>
 
                 </div>
@@ -61,11 +61,11 @@
                 <div class="input-group2">
 
                     <div class="input-box">
-                        <input id="password" type="password" name="password" placeholder="Senha" required>
+                        <input id="senha" type="password" name="senha" placeholder="Senha" required>
                     </div>
 
                     <div class="input-box">
-                        <input id="confirmPassword" type="password" name="confirmPassword" placeholder="Confirmação da senha" required>
+                        <input id="confirmacao_senha" type="password" name="confirmacao_senha" placeholder="Confirmação da senha" required>
                     </div>
 
                 </div>          


### PR DESCRIPTION
@G4brielSiq  Acabou trocando os nomes dos atributos no HTML para ingles e afetou o get mappin do /process_add. O que acabou fazendo que o cadastro só recebesse o email e o agree, e o resto NULL.